### PR TITLE
Fixed .RSSLink warning

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -11,8 +11,8 @@
 
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    {{ if .RSSLink -}}
-      <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
+    {{ range .AlternativeOutputFormats -}}
+    <link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
     {{ end -}}
 
     <!-- Styles and Fonts -->


### PR DESCRIPTION
Fixed a warning which appears with Hugo v0.55.6:

```
Building sites … WARN 2019/06/19 08:14:51 Page's .RSSLink is deprecated and will be removed in a future release. Use the Output Format's link, e.g. something like:
    {{ with .OutputFormats.Get "RSS" }}{{ .RelPermalink }}{{ end }}.
```

Replaced it with what is described [here](https://gohugo.io/templates/output-formats/#list-output-formats):

```
{{ range .AlternativeOutputFormats -}}
<link rel="{{ .Rel }}" type="{{ .MediaType.Type }}" href="{{ .Permalink | safeURL }}">
{{ end -}}
```