### PR TITLE
Footer URL to use GitHub repository

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -3,7 +3,7 @@
   {{ with .Site.Params.twitter }}<section class="twitter"><a class="icon-twitter" href="https://twitter.com/{{ . }}"> {{ . }}</a></section>{{ end }}
   {{ with .Site.Params.facebook }}<section class="facebook"><a class="icon-facebook" href="https://www.facebook.com/{{ . }}"> {{ . }}</a></section>{{ end }}
   <section class="copyright">&copy; {{ now.Format "2006" }} {{ .Site.Title }}</section>
-  <section class="poweredby"><a href="http://thedarkroast.com/arabica">Arabica</a> theme by Sean Lunsford. Published with <a href="https://gohugo.io">Hugo</a>.</section>
+  <section class="poweredby"><a href="https://github.com/nirocfz/arabica">Arabica</a> theme by Sean Lunsford. Published with <a href="https://gohugo.io">Hugo</a>.</section>
 </footer>
 <!-- custom js -->
 {{ range .Site.Params.customJS }}


### PR DESCRIPTION
The current footer URL is broken, pointing to a site that's no longer available. A proper URL should be used, otherwise removed. To give proper attribution and a path, I am suggesting that the GitHub project URL should be used instead of the current personal URL.